### PR TITLE
Abstrai obtenção de tokens de serviços externos em módulo dedicado

### DIFF
--- a/tools/external_services.py
+++ b/tools/external_services.py
@@ -1,0 +1,22 @@
+import os
+
+try:
+    from google.colab import userdata
+except ImportError:
+    userdata = None
+
+def obter_token_github():
+    """
+    Obtém o token do Github, preferencialmente do ambiente Colab.
+    """
+    if userdata:
+        return userdata.get('GITHUB_TOKEN')
+    return os.environ.get('GITHUB_TOKEN')
+
+def obter_token_openai():
+    """
+    Obtém o token da OpenAI, preferencialmente do ambiente Colab.
+    """
+    if userdata:
+        return userdata.get('OPENAI_API_KEY')
+    return os.environ.get('OPENAI_API_KEY')


### PR DESCRIPTION
Este PR cria o módulo tools/external_services.py para centralizar e abstrair a obtenção de tokens de autenticação (Github e OpenAI). Com isso, reduz-se o acoplamento do código principal a detalhes de infraestrutura, facilitando a substituição/mocking em testes e melhorando a manutenibilidade.