### PR TITLE
Testes de Validação e Contrato da Função `validation`

### DIFF
--- a/tests/test_validation_tc003_tipo_analise_invalido.py
+++ b/tests/test_validation_tc003_tipo_analise_invalido.py
@@ -1,0 +1,7 @@
+import pytest
+from agents.agente_revisor import validation
+
+def test_validation_tipo_analise_invalido():
+    with pytest.raises(ValueError) as exc:
+        validation(tipo_analise='foo', repositorio='org/repo', codigo=None)
+    assert "Tipo de análise 'foo' é inválido" in str(exc.value)

--- a/tests/test_validation_tc004_ambos_repositorio_e_codigo_ausentes.py
+++ b/tests/test_validation_tc004_ambos_repositorio_e_codigo_ausentes.py
@@ -1,0 +1,7 @@
+import pytest
+from agents.agente_revisor import validation
+
+def test_validation_ambos_repositorio_e_codigo_ausentes():
+    with pytest.raises(ValueError) as exc:
+        validation(tipo_analise='design', repositorio=None, codigo=None)
+    assert "obrigatório fornecer 'repositorio' ou 'codigo'" in str(exc.value)

--- a/tests/test_validation_tc005_ambos_presentes_codigo_precede.py
+++ b/tests/test_validation_tc005_ambos_presentes_codigo_precede.py
@@ -1,0 +1,6 @@
+import pytest
+from agents.agente_revisor import validation
+
+def test_validation_ambos_presentes_codigo_precede():
+    result = validation(tipo_analise='seguranca', repositorio='org/repo', codigo='print(1)')
+    assert result == 'print(1)'

--- a/tests/test_validation_tc006_tipo_analise_case_sensitive.py
+++ b/tests/test_validation_tc006_tipo_analise_case_sensitive.py
@@ -1,0 +1,7 @@
+import pytest
+from agents.agente_revisor import validation
+
+def test_validation_tipo_analise_case_sensitive():
+    with pytest.raises(ValueError) as exc:
+        validation(tipo_analise='DeSiGn', repositorio='org/repo', codigo=None)
+    assert "Tipo de análise 'DeSiGn' é inválido" in str(exc.value)

--- a/tests/test_validation_tc009_tipo_analise_none.py
+++ b/tests/test_validation_tc009_tipo_analise_none.py
@@ -1,0 +1,7 @@
+import pytest
+from agents.agente_revisor import validation
+
+def test_validation_tipo_analise_none():
+    with pytest.raises(ValueError) as exc:
+        validation(tipo_analise=None, repositorio='org/repo', codigo=None)
+    assert "Tipo de análise 'None' é inválido" in str(exc.value)

--- a/tests/test_validation_tc012_tipo_analise_string_longa.py
+++ b/tests/test_validation_tc012_tipo_analise_string_longa.py
@@ -1,0 +1,8 @@
+import pytest
+from agents.agente_revisor import validation
+
+def test_validation_tipo_analise_string_longa():
+    tipo_analise = 'd' * 1000
+    with pytest.raises(ValueError) as exc:
+        validation(tipo_analise=tipo_analise, repositorio='org/repo', codigo=None)
+    assert f"Tipo de análise '{tipo_analise}' é inválido" in str(exc.value)

--- a/tests/test_validation_tc013_repositorio_none_codigo_none_tipo_analise_valido.py
+++ b/tests/test_validation_tc013_repositorio_none_codigo_none_tipo_analise_valido.py
@@ -1,0 +1,7 @@
+import pytest
+from agents.agente_revisor import validation
+
+def test_validation_repositorio_none_codigo_none_tipo_analise_valido():
+    with pytest.raises(ValueError) as exc:
+        validation(tipo_analise='design', repositorio=None, codigo=None)
+    assert "obrigatório fornecer 'repositorio' ou 'codigo'" in str(exc.value)


### PR DESCRIPTION
Este PR introduz testes unitários que garantem a robustez do contrato da função `validation`. Ele valida a rejeição de tipos de análise inválidos, obrigatoriedade de parâmetros essenciais, tipos de dados incorretos e precedência de parâmetros, alinhado às políticas de robustez e previsibilidade da Protecta Seguros.