### PR TITLE
Abstrai obtenção de credenciais e segredos para facilitar portabilidade e testes

### DIFF
--- a/tools/secrets_provider.py
+++ b/tools/secrets_provider.py
@@ -1,0 +1,31 @@
+import os
+try:
+    from google.colab import userdata
+except ImportError:
+    userdata = None
+
+def obter_github_token():
+    """
+    Abstrai a obtenção do token do GitHub, seja via Colab ou variável de ambiente.
+    """
+    if userdata is not None:
+        token = userdata.get('github_token')
+        if token:
+            return token
+    token = os.environ.get('GITHUB_TOKEN')
+    if token:
+        return token
+    raise ValueError("Token do GitHub não encontrado em Colab nem variável de ambiente.")
+
+def obter_openai_api_key():
+    """
+    Abstrai a obtenção da chave da API OpenAI, seja via Colab ou variável de ambiente.
+    """
+    if userdata is not None:
+        key = userdata.get('OPENAI_API_KEY')
+        if key:
+            return key
+    key = os.environ.get('OPENAI_API_KEY')
+    if key:
+        return key
+    raise ValueError("Chave da API da OpenAI não encontrada em Colab nem variável de ambiente.")


### PR DESCRIPTION
Este PR cria o módulo 'secrets_provider' e ajusta dependências para desacoplar a obtenção de segredos do ambiente de execução, tornando o sistema mais portável e testável.