### PR TITLE
Testes: contrato público, agente com DI e app Flask

### DIFF
--- a/tests/test_agente_revisor.py
+++ b/tests/test_agente_revisor.py
@@ -1,0 +1,50 @@
+import pytest
+from agents import agente_revisor
+
+
+def test_validation_tipo_invalido():
+    with pytest.raises(ValueError):
+        agente_revisor.validation(tipo_analise='invalido', repositorio='owner/repo')
+
+
+def test_validation_sem_fonte():
+    with pytest.raises(ValueError):
+        agente_revisor.validation(tipo_analise='pentest')
+
+
+def test_main_com_codigo_e_llm_injetado():
+    def fake_llm_runner(**kwargs):
+        assert kwargs['tipo_analise'] == 'pentest'
+        assert 'print(' in kwargs['codigo']
+        return 'OK'
+
+    resultado = agente_revisor.executar_analise(
+        tipo_analise='pentest',
+        codigo="print('hello')",
+        llm_runner=fake_llm_runner,
+    )
+
+    assert resultado['tipo_analise'] == 'pentest'
+    assert resultado['resultado'] == 'OK'
+
+
+def test_main_usa_code_fetcher_injetado():
+    def fake_fetcher(repositorio, tipo_analise, **kwargs):
+        assert repositorio == 'owner/repo'
+        assert tipo_analise == 'pentest'
+        return {'file.py': 'print(42)'}
+
+    def fake_llm_runner(**kwargs):
+        # O código chega como str(); dicionários são transformados em string
+        assert 'file.py' in kwargs['codigo']
+        return 'ANALISE_FALSA'
+
+    resultado = agente_revisor.executar_analise(
+        tipo_analise='pentest',
+        repositorio='owner/repo',
+        code_fetcher=fake_fetcher,
+        llm_runner=fake_llm_runner,
+    )
+
+    assert resultado['tipo_analise'] == 'pentest'
+    assert resultado['resultado'] == 'ANALISE_FALSA'

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,27 @@
+import json
+import types
+
+import app as flask_app
+
+
+def test_endpoint_executar_analise_monkeypatch(monkeypatch):
+    # Monkeypatch do agente para evitar I/O real
+    def fake_executar_analise(**kwargs):
+        return {"tipo_analise": kwargs['tipo_analise'], "resultado": "RESPOSTA_FAKE"}
+
+    monkeypatch.setattr(flask_app.agente_revisor, 'executar_analise', fake_executar_analise)
+
+    client = flask_app.app.test_client()
+
+    payload = {
+        "tipo_analise": "pentest",
+        "repositorio": "owner/repo",
+        "instrucoes_extras": ""
+    }
+
+    resp = client.post('/executar_analise', data=json.dumps(payload), content_type='application/json')
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['tipo_analise'] == 'pentest'
+    assert data['resultado'] == 'RESPOSTA_FAKE'

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -1,0 +1,6 @@
+from agents import agente_revisor
+
+
+def test_executar_analise_existe_e_eh_callable():
+    assert hasattr(agente_revisor, 'executar_analise'), 'Função executar_analise não está exposta no módulo agente_revisor'
+    assert callable(agente_revisor.executar_analise), 'executar_analise não é chamável'


### PR DESCRIPTION
Adiciona suíte de testes que valida a função pública executar_analise, cobre o fluxo feliz do agente com injeção de dependências e testa o servidor Flask via test_client com monkeypatch. Evita I/O real e acelera o CI.