### PR TITLE
Refatoração para aceitar token como parâmetro e evitar dependência de ambiente

### DIFF
--- a/tools/github_reader.py
+++ b/tools/github_reader.py
@@ -1,10 +1,13 @@
 import re
 from github import Github
 from github.Auth import Token
-from google.colab import userdata
+import os
 
-def conection(repositorio: str):
-    GITHUB_TOKEN = userdata.get('github_token')
+
+def conection(repositorio: str, token: str = None):
+    GITHUB_TOKEN = token or os.getenv('GITHUB_TOKEN')
+    if not GITHUB_TOKEN:
+        raise ValueError("Token do GitHub não encontrado.")
     auth = Token(GITHUB_TOKEN)
     g = Github(auth=auth)
     return g.get_repo(repositorio)
@@ -52,9 +55,9 @@ def _leitura_recursiva_com_debug(repo, extensoes, path="", arquivos_do_repo=None
     return arquivos_do_repo
 
 
-def main(repo, tipo_de_analise: str):
+def main(repo, tipo_de_analise: str, token: str = None):
 
-    repositorio_final = conection(repositorio=repo)
+    repositorio_final = conection(repositorio=repo, token=token)
 
     extensoes_alvo = MAPEAMENTO_TIPO_EXTENSOES.get(tipo_de_analise.lower())
 


### PR DESCRIPTION
Este PR modifica o componente para aceitar o token como parâmetro, removendo a dependência de um ambiente específico. Isso aumenta a portabilidade e a segurança do sistema. prioridade_de_revisao: NORMAL, ordem_de_merge_sugerida: 2, revisores_sugeridos: Engenheiro de DevOps/SRE, Desenvolvedor Sênior (Backend)