### PR TITLE
Refatora fluxo de execução: main como entrypoint e wrapper executar_analise para compatibilidade

### DIFF
--- a/agents/agente_revisor.py
+++ b/agents/agente_revisor.py
@@ -12,7 +12,7 @@ def code_from_repo(repositorio: str,
                    tipo_analise: str):
 
     try:
-      print('Iniciando a leitura do repositório: '+ repositorio)
+      print('Iniciando a leitura do repositório: ' + repositorio)
       codigo_para_analise = github_reader.main(repo=repositorio,
                                                  tipo_de_analise=tipo_analise)
       
@@ -45,14 +45,14 @@ def main(tipo_analise: str,
          codigo: Optional[str] = None,
          instrucoes_extras: str = "",
          model_name: str = modelo_llm,
-         max_token_out: int = max_tokens_saida)-> Dict[str, Any]:
+         max_token_out: int = max_tokens_saida) -> Dict[str, Any]:
 
   codigo_para_analise = validation(tipo_analise=tipo_analise,
                                    repositorio=repositorio,
                                    codigo=codigo)
                                    
   if not codigo_para_analise:
-    return ({"tipo_analise": tipo_analise, "resultado": 'Não foi fornecido nenhum código para análise'})
+    return {"tipo_analise": tipo_analise, "resultado": 'Não foi fornecido nenhum código para análise'}
     
   else: 
     resultado = executar_analise_llm(
@@ -64,3 +64,20 @@ def main(tipo_analise: str,
         )
         
     return {"tipo_analise": tipo_analise, "resultado": resultado}
+
+# Wrapper de compatibilidade retroativa
+
+def executar_analise(tipo_analise: str,
+                     repositorio: Optional[str] = None,
+                     codigo: Optional[str] = None,
+                     instrucoes_extras: str = "",
+                     model_name: str = modelo_llm,
+                     max_token_out: int = max_tokens_saida) -> Dict[str, Any]:
+    return main(
+        tipo_analise=tipo_analise,
+        repositorio=repositorio,
+        codigo=codigo,
+        instrucoes_extras=instrucoes_extras,
+        model_name=model_name,
+        max_token_out=max_token_out
+    )

--- a/teste_git_hub.py
+++ b/teste_git_hub.py
@@ -7,20 +7,6 @@ Original file is located at
     https://colab.research.google.com/drive/11ZTKLHaPzrTy8tcu3IYFSCefnnVtvIEF
 """
 
-#!pip install PyGithub
-
-from agents import agente_revisor
-
-nome_do_repositorio = "LucioFlavioRosa/agent-vinna"
-
-resposta_desing = agente_revisor.executar_analise(tipo_analise='pentest', repositorio=nome_do_repositorio)
-#resposta_desing = agente_revisor_design.main(repositorio=nome_do_repositorio)
-#resposta_seguranca = agente_revisor_seguranca.main(repositorio=nome_do_repositorio)
-#resposta_pen_test = agente_pen_test.main(repositorio=nome_do_repositorio)
-
-print(resposta_desing['resultado'])
-
-# app.py
 from flask import Flask, request, jsonify
 from agents import agente_revisor
 import traceback
@@ -52,7 +38,7 @@ def rodar_analise():
     try:
         print(f"INFO: Iniciando análise do tipo '{tipo_analise}'...")
 
-        resultado = agente_revisor.executar_analise(
+        resultado = agente_revisor.main(
             tipo_analise=tipo_analise,
             repositorio=repositorio,
             codigo=codigo,
@@ -74,4 +60,3 @@ def index():
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5000, debug=True)
-


### PR DESCRIPTION
Este PR padroniza o ponto de entrada da aplicação usando main e adiciona um wrapper executar_analise para compatibilidade retroativa. Além disso, remove execução no topo de teste_git_hub.py para evitar efeitos colaterais e atualiza chamadas para usar main. Benefícios: previsibilidade, testabilidade e redução de side effects. prioridade_de_revisao: ALTA, ordem_de_merge_sugerida: 1, revisores_sugeridos: Desenvolvedor Sênior (Backend), Engenheiro de QA