### PR TITLE
Agente revisor: alias executar_analise e serialização determinística de dict

### DIFF
--- a/agents/agente_revisor.py
+++ b/agents/agente_revisor.py
@@ -55,12 +55,28 @@ def main(tipo_analise: str,
     return ({"tipo_analise": tipo_analise, "resultado": 'Não foi fornecido nenhum código para análise'})
     
   else: 
+    # Serialização estável do código para envio ao LLM
+    if isinstance(codigo_para_analise, dict):
+        partes = []
+        for path in sorted(codigo_para_analise.keys()):
+            conteudo_arquivo = codigo_para_analise[path]
+            conteudo_arquivo = "" if conteudo_arquivo is None else str(conteudo_arquivo)
+            partes.append(f"\n===== FILE: {path} =====\n{conteudo_arquivo}")
+        codigo_serializado = "".join(partes)
+    else:
+        codigo_serializado = str(codigo_para_analise)
+
     resultado = executar_analise_llm(
             tipo_analise=tipo_analise,
-            codigo=str(codigo_para_analise),
+            codigo=codigo_serializado,
             analise_extra=instrucoes_extras,
             model_name=model_name,
             max_token_out=max_token_out
         )
         
     return {"tipo_analise": tipo_analise, "resultado": resultado}
+
+# Alias público para manter compatibilidade com consumidores
+
+def executar_analise(*args, **kwargs):
+    return main(*args, **kwargs)


### PR DESCRIPTION
Cria o alias executar_analise delegando para main para estabilizar a interface do agente e adiciona serialização estável quando o código for dict, melhorando determinismo e reprodutibilidade. prioridade_de_revisao: NORMAL, ordem_de_merge_sugerida: 2, revisores_sugeridos: Desenvolvedor Sênior (Backend), Engenheiro de QA