### PR TITLE
Testes: adiciona suíte de testes unitários para agente e ferramentas

### DIFF
--- a/tests/test_agente_revisor.py
+++ b/tests/test_agente_revisor.py
@@ -1,0 +1,134 @@
+import importlib
+import sys
+import types
+import pytest
+
+
+# Utilitário: injeta um módulo fake google.colab.userdata para evitar dependência externa
+class _FakeUserDataModule(types.ModuleType):
+    def __init__(self, token_value="fake-token"):
+        super().__init__("google.colab.userdata")
+        self._token_value = token_value
+
+    def get(self, key):
+        # usado em github_reader e revisor_geral
+        return self._token_value
+
+
+def _install_fake_colab(token_value="fake-token"):
+    google_mod = types.ModuleType("google")
+    colab_mod = types.ModuleType("google.colab")
+    userdata_mod = _FakeUserDataModule(token_value=token_value)
+    sys.modules["google"] = google_mod
+    sys.modules["google.colab"] = colab_mod
+    sys.modules["google.colab.userdata"] = userdata_mod
+
+
+# Antes de importar agente_revisor, garantimos que google.colab.userdata existe
+_install_fake_colab()
+
+# Também injetamos um stub para tools.revisor_geral a fim de evitar dependência de OpenAI no import
+stub_revisor = types.ModuleType("tools.revisor_geral")
+
+def _stub_executar_analise_llm(**kwargs):
+    return "STUB_EXECUCAO"
+
+stub_revisor.executar_analise_llm = _stub_executar_analise_llm
+sys.modules["tools.revisor_geral"] = stub_revisor
+
+# Agora podemos importar o módulo sob teste
+import agents.agente_revisor as ar
+
+
+def test_validation_tipo_analise_invalido_gera_valueerror():
+    with pytest.raises(ValueError) as exc:
+        ar.validation(tipo_analise="invalido")
+    msg = str(exc.value)
+    assert "Tipo de análise 'invalido' é inválido" in msg
+    assert "analises_validas" not in msg  # apenas checa mensagem com lista
+    for item in ["design", "pentest", "seguranca", "terraform"]:
+        assert item in msg
+
+
+def test_validation_repo_ou_codigo_obrigatorio():
+    with pytest.raises(ValueError) as exc:
+        ar.validation(tipo_analise="pentest", repositorio=None, codigo=None)
+    assert "É obrigatório fornecer 'repositorio' ou 'codigo'" in str(exc.value)
+
+
+def test_validation_retorna_codigo_quando_fornecido():
+    # Se codigo for fornecido, não deve chamar code_from_repo
+    sentinel = "print('ok')"
+
+    def _boom(*a, **k):
+        raise AssertionError("code_from_repo não deveria ser chamado quando 'codigo' é fornecido")
+
+    original = ar.code_from_repo
+    try:
+        ar.code_from_repo = _boom  # garantir que não será chamado
+        saida = ar.validation(tipo_analise="pentest", codigo=sentinel)
+        assert saida == sentinel
+    finally:
+        ar.code_from_repo = original
+
+
+def test_validation_chama_code_from_repo_quando_codigo_none(monkeypatch):
+    called = {}
+
+    def fake_code_from_repo(repositorio: str, tipo_analise: str):
+        called["args"] = (repositorio, tipo_analise)
+        return {"file.py": "print('x')"}
+
+    monkeypatch.setattr(ar, "code_from_repo", fake_code_from_repo)
+    out = ar.validation(tipo_analise="pentest", repositorio="org/repo", codigo=None)
+    assert out == {"file.py": "print('x')"}
+    assert called["args"] == ("org/repo", "pentest")
+
+
+def test_code_from_repo_lanca_runtimeerror_quando_github_reader_falha(monkeypatch):
+    def boom(**kwargs):
+        raise Exception("falhou GH")
+
+    monkeypatch.setattr(ar.github_reader, "main", boom)
+    with pytest.raises(RuntimeError) as exc:
+        ar.code_from_repo(repositorio="org/repo", tipo_analise="pentest")
+    assert "Falha ao executar a análise de 'pentest'" in str(exc.value)
+
+
+def test_main_quando_codigo_vazio_retorna_mensagem_sem_codigo():
+    resp = ar.main(tipo_analise="pentest", codigo="")
+    assert resp["tipo_analise"] == "pentest"
+    assert resp["resultado"] == "Não foi fornecido nenhum código para análise"
+
+
+def test_main_chama_executar_analise_llm_e_formata_resposta(monkeypatch):
+    captured = {}
+
+    def fake_exec_llm(tipo_analise, codigo, analise_extra, model_name, max_token_out):
+        captured.update({
+            "tipo_analise": tipo_analise,
+            "codigo": codigo,
+            "analise_extra": analise_extra,
+            "model_name": model_name,
+            "max_token_out": max_token_out,
+        })
+        return "RESULTADO_OK"
+
+    monkeypatch.setattr(ar, "executar_analise_llm", fake_exec_llm)
+    resp = ar.main(tipo_analise="pentest", codigo="print('x')", instrucoes_extras="", model_name="m", max_token_out=123)
+    assert resp == {"tipo_analise": "pentest", "resultado": "RESULTADO_OK"}
+    assert captured["tipo_analise"] == "pentest"
+    assert captured["codigo"] == "print('x')"
+    assert captured["model_name"] == "m"
+    assert captured["max_token_out"] == 123
+
+
+def test_modulo_expoe_funcao_executar_analise_para_compatibilidade(monkeypatch):
+    assert hasattr(ar, "executar_analise"), "O módulo deve expor a função executar_analise para compatibilidade"
+
+    def fake_exec_llm(tipo_analise, codigo, analise_extra, model_name, max_token_out):
+        return "OK_WRAPPER"
+
+    monkeypatch.setattr(ar, "executar_analise_llm", fake_exec_llm)
+    out = ar.executar_analise(tipo_analise="pentest", codigo="x")
+    assert out == {"tipo_analise": "pentest", "resultado": "OK_WRAPPER"}

--- a/tests/test_github_reader.py
+++ b/tests/test_github_reader.py
@@ -1,0 +1,129 @@
+import importlib
+import sys
+import types
+import pytest
+
+
+def _install_fake_colab(token_value="fake-token"):
+    google_mod = types.ModuleType("google")
+    colab_mod = types.ModuleType("google.colab")
+    class _UserData(types.ModuleType):
+        def get(self, key):
+            return token_value
+    userdata_mod = _UserData("google.colab.userdata")
+    sys.modules["google"] = google_mod
+    sys.modules["google.colab"] = colab_mod
+    sys.modules["google.colab.userdata"] = userdata_mod
+
+
+_install_fake_colab()
+
+import tools.github_reader as gh
+
+
+def test_main_tipo_nao_mapeado_le_todos_os_arquivos(monkeypatch):
+    # Força conection a retornar um repo sentinel e verifica que extensoes=None é passado
+    monkeypatch.setattr(gh, "conection", lambda repositorio: "REPO_SENTINEL")
+
+    seen = {}
+
+    def fake_read(repo, extensoes, path="", arquivos_do_repo=None):
+        seen["repo"] = repo
+        seen["extensoes"] = extensoes
+        return {"a.txt": "conteudo"}
+
+    monkeypatch.setattr(gh, "_leitura_recursiva_com_debug", fake_read)
+
+    # tipo nao mapeado (ex.: pentest) => extensoes_alvo = None
+    out = gh.main(repo="org/repo", tipo_de_analise="pentest")
+    assert out == {"a.txt": "conteudo"}
+    assert seen["repo"] == "REPO_SENTINEL"
+    assert seen["extensoes"] is None
+
+
+def test__leitura_recursiva_filtra_por_extensao_e_dockerfile():
+    # Monta uma árvore fake de arquivos
+    class Node:
+        def __init__(self, type_, path, name=None, content=b""):
+            self.type = type_
+            self.path = path
+            self.name = name if name is not None else path.split("/")[-1]
+            self.decoded_content = content
+
+    class FakeRepo:
+        def __init__(self):
+            self._store = {
+                "": [
+                    Node("dir", "dir1"),
+                    Node("file", "a.tf", content=b"resource \"x\" {}"),
+                    Node("file", "b.py", content=b"print('x')"),
+                    Node("file", "Dockerfile", name="Dockerfile", content=b"FROM python:3.11"),
+                ],
+                "dir1": [
+                    Node("file", "dir1/c.tfvars", content=b"var=1"),
+                    Node("file", "dir1/d.txt", content=b"txt"),
+                ],
+            }
+        def get_contents(self, path=""):
+            return self._store.get(path, [])
+
+    repo = FakeRepo()
+    extensoes = [".tf", ".tfvars", "Dockerfile"]
+    out = gh._leitura_recursiva_com_debug(repo, extensoes)
+
+    assert "a.tf" in out
+    assert "Dockerfile" in out
+    assert "dir1/c.tfvars" in out
+    assert "b.py" not in out
+    assert "dir1/d.txt" not in out
+
+
+def test__leitura_recursiva_trata_unicode_decode_error_sem_interromper(capsys):
+    class Node:
+        def __init__(self, type_, path, name=None, content=b""):
+            self.type = type_
+            self.path = path
+            self.name = name if name is not None else path.split("/")[-1]
+            self.decoded_content = content
+
+    class FakeRepo:
+        def __init__(self):
+            self._store = {
+                "": [
+                    Node("file", "ok.tf", content=b"ok=1"),
+                    Node("file", "bad.tf", content=b"\xff"),  # inválido UTF-8
+                ]
+            }
+        def get_contents(self, path=""):
+            return self._store.get(path, [])
+
+    repo = FakeRepo()
+    out = gh._leitura_recursiva_com_debug(repo, extensoes=[".tf"])
+    # Arquivo inválido não deve estar presente
+    assert "ok.tf" in out
+    assert "bad.tf" not in out
+
+
+def test_conection_usa_token_e_get_repo(monkeypatch):
+    # Fakes para Token e Github
+    created = {}
+
+    class FakeToken:
+        def __init__(self, value):
+            created["token_value"] = value
+
+    class FakeGithub:
+        def __init__(self, auth=None):
+            created["auth"] = auth
+        def get_repo(self, repo):
+            created["repo"] = repo
+            return f"REPO::{repo}"
+
+    monkeypatch.setattr(gh, "Token", FakeToken)
+    monkeypatch.setattr(gh, "Github", FakeGithub)
+
+    repo = gh.conection("org/repo")
+    assert repo == "REPO::org/repo"
+    assert created["token_value"] == "fake-token"
+    assert isinstance(created["auth"], FakeToken)
+    assert created["repo"] == "org/repo"

--- a/tests/test_revisor_geral.py
+++ b/tests/test_revisor_geral.py
@@ -1,0 +1,117 @@
+import importlib
+import sys
+import types
+import pytest
+
+
+# Injeta módulos fake antes do import de revisor_geral
+
+def _install_fake_colab(key="fake-openai-key"):
+    google_mod = types.ModuleType("google")
+    colab_mod = types.ModuleType("google.colab")
+    class _UserData(types.ModuleType):
+        def get(self, k):
+            return key
+    userdata_mod = _UserData("google.colab.userdata")
+    sys.modules["google"] = google_mod
+    sys.modules["google.colab"] = colab_mod
+    sys.modules["google.colab.userdata"] = userdata_mod
+
+
+def _install_fake_openai():
+    class FakeOpenAI(types.ModuleType):
+        class OpenAI:
+            def __init__(self, api_key=None):
+                self.api_key = api_key
+                # estrutura esperada: .chat.completions.create
+                class _Completions:
+                    def __init__(self):
+                        self._create = None
+                    def create(self, *a, **kw):
+                        if self._create is None:
+                            raise NotImplementedError
+                        return self._create(*a, **kw)
+                class _Chat:
+                    def __init__(self):
+                        self.completions = _Completions()
+                self.chat = _Chat()
+    sys.modules["openai"] = FakeOpenAI("openai")
+
+
+_install_fake_colab()
+_install_fake_openai()
+
+# Importa o módulo após preparar os stubs
+import tools.revisor_geral as rg
+
+
+def test_carregar_prompt_arquivo_inexistente_gera_valueerror():
+    with pytest.raises(ValueError) as exc:
+        rg.carregar_prompt("tipo_que_nao_existe")
+    assert "Arquivo de prompt para a análise" in str(exc.value)
+
+
+def test_executar_analise_llm_fluxo_sucesso_sem_instrucao_extra(monkeypatch):
+    # Mock do prompt
+    monkeypatch.setattr(rg, "carregar_prompt", lambda tipo: "PROMPT_SISTEMA")
+
+    captured = {}
+
+    class Choice:
+        def __init__(self, content):
+            class Msg:
+                def __init__(self, c):
+                    self.content = c
+            self.message = Msg(content)
+
+    def fake_create(model, messages, temperature, max_tokens):
+        captured["model"] = model
+        captured["messages"] = messages
+        captured["temperature"] = temperature
+        captured["max_tokens"] = max_tokens
+        return types.SimpleNamespace(choices=[Choice("RESPOSTA_OK")])
+
+    # injeta o create fake
+    rg.openai_client.chat.completions._create = fake_create
+
+    out = rg.executar_analise_llm(
+        tipo_analise="pentest",
+        codigo="print('x')",
+        analise_extra="   ",  # em branco
+        model_name="gpt",
+        max_token_out=321,
+    )
+    assert out == "RESPOSTA_OK"
+
+    assert captured["model"] == "gpt"
+    assert captured["max_tokens"] == 321
+    assert len(captured["messages"]) == 3
+    assert captured["messages"][0]["role"] == "system"
+    assert captured["messages"][2]["content"].startswith("Nenhuma instrução extra fornecida")
+
+
+def test_executar_analise_llm_trata_excecao_da_api(monkeypatch):
+    # Mock do prompt
+    monkeypatch.setattr(rg, "carregar_prompt", lambda tipo: "PROMPT")
+
+    def fake_create_fail(*a, **k):
+        raise Exception("falha api")
+
+    rg.openai_client.chat.completions._create = fake_create_fail
+
+    with pytest.raises(RuntimeError) as exc:
+        rg.executar_analise_llm(
+            tipo_analise="pentest",
+            codigo="x",
+            analise_extra="y",
+            model_name="m",
+            max_token_out=10,
+        )
+    assert "Erro ao comunicar com a OpenAI" in str(exc.value)
+
+
+def test_modulo_importa_quando_api_key_disponivel():
+    # Reimporta assegurando que a API key existe (stub já instalado)
+    mod = importlib.reload(rg)
+    assert hasattr(mod, "openai_client")
+    assert mod.OPENAI_API_KEY == "fake-openai-key"


### PR DESCRIPTION
Cria testes unitários para validar fluxos principais, validações e tratamento de erros nos módulos do agente e ferramentas, cobrindo compatibilidade via executar_analise, leitura do GitHub e chamadas ao revisor geral com mocks. Depende do PR 1. prioridade_de_revisao: NORMAL, ordem_de_merge_sugerida: 2, revisores_sugeridos: Engenheiro de QA, Qualquer Membro da Equipe