### PR TITLE
Adiciona utilitário desacoplado para leitura de segredos no ambiente Colab

### DIFF
--- a/tools/segredos.py
+++ b/tools/segredos.py
@@ -1,0 +1,19 @@
+import os
+import logging
+
+def get_secret(key: str):
+    """Obtém segredo de os.environ ou do Colab se disponível."""
+    valor = os.environ.get(key)
+    if valor:
+        return valor
+    try:
+        import google.colab
+        from google.colab import userdata
+        valor = userdata.get(key)
+        if valor:
+            return valor
+    except ImportError:
+        logging.debug("google.colab não disponível para leitura do segredo %s", key)
+    except Exception as e:
+        logging.error(f"Erro ao tentar obter segredo '{key}' do Colab: {e}")
+    return None


### PR DESCRIPTION
Este PR introduz um novo módulo utilitário para desacoplar a leitura de segredos do ambiente Colab, conforme o plano de melhoria. Essa mudança cria uma base para futuras integrações seguras e padronizadas no gerenciamento de segredos. prioridade_de_revisao: NORMAL, ordem_de_merge_sugerida: 2, revisores_sugeridos: Engenheiro de DevOps/SRE, Desenvolvedor Sênior (Backend)